### PR TITLE
:bug: `fix` Fix flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       in
       {
         packages = let
-          nixos-conf-editor = pkgs.callPackages ./default.nix {};
+          nixos-conf-editor = pkgs.callPackage ./default.nix {};
         in {
           inherit nixos-conf-editor;
           default = nixos-conf-editor;

--- a/flake.nix
+++ b/flake.nix
@@ -10,22 +10,14 @@
         pkgs = import nixpkgs {
           inherit system;
         };
-        name = "nixos-conf-editor";
       in
-      rec
       {
-        packages.${name} = pkgs.callPackage ./default.nix { };
-
-        # `nix build`
-        defaultPackage = packages.${name}; # legacy
-        packages.default = packages.${name};
-
-        # `nix run`
-        apps.${name} = utils.lib.mkApp {
-          inherit name;
-          drv = packages.${name};
+        packages = let
+          nixos-conf-editor = pkgs.callPackages ./default.nix {};
+        in {
+          inherit nixos-conf-editor;
+          default = nixos-conf-editor;
         };
-        defaultApp = apps.${name};
 
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [


### PR DESCRIPTION
Resolves: #11 

`nix run` will build and run packages as well as apps, so `apps` was a redundancy.